### PR TITLE
Trata CEP com logradouro com numero

### DIFF
--- a/src/pages/CadastroImovel/components/Imovel/index.js
+++ b/src/pages/CadastroImovel/components/Imovel/index.js
@@ -55,7 +55,7 @@ const Imovel = () => {
                           "endereco",
                           response.data.tipo_logradouro +
                             " " +
-                            response.data.logradouro
+                            response.data.logradouro.split(",")[0]
                         );
                         form.change("cidade", response.data.cidade);
                         form.change("uf", response.data.uf);


### PR DESCRIPTION
Este PR:
- trata CEPs com logradouros que já vem com número no cadastro de imóveis