### PR TITLE
Feature/31787 remover campo setor

### DIFF
--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -172,12 +172,12 @@ export const normalizarSetores = (options) => {
 
 export const normalizarPerfis = (options) => {
   const options_ = [
-    { label: "Selecione", value: undefined },
-    { label: "SEM PERMISSAO", value: "SEM PERMISSAO" },
+    { label: "Selecione", value: undefined }
   ];
   options.forEach((option) => {
     options_.push({ label: option.nome, value: option.id });
   });
+  options_.push({ label: "SEM PERMISSAO", value: "SEM PERMISSAO" })
   return options_;
 };
 

--- a/src/pages/AreaLogada/Permissionamento/componentes/ModalEditarUsuario/index.jsx
+++ b/src/pages/AreaLogada/Permissionamento/componentes/ModalEditarUsuario/index.jsx
@@ -84,7 +84,7 @@ export const ModalEditarUsuario = ({
                   type="text"
                 />
                 <div className="row">
-                  <div className="col-sm-5 col-12">
+                  <div className="col-sm-6 col-12">
                     <Field
                       component={SelectText}
                       name="secretaria_"
@@ -93,7 +93,7 @@ export const ModalEditarUsuario = ({
                       naoDesabilitarPrimeiraOpcao
                     />
                   </div>
-                  <div className="col-sm-5 col-12">
+                  <div className="col-sm-6 col-12">
                     <Field
                       component={SelectText}
                       name="dre_"

--- a/src/pages/AreaLogada/Permissionamento/componentes/ModalEditarUsuario/index.jsx
+++ b/src/pages/AreaLogada/Permissionamento/componentes/ModalEditarUsuario/index.jsx
@@ -10,7 +10,6 @@ import { BUTTON_STYLE, BUTTON_TYPE } from "components/Botao/constants";
 import { SelectText } from "components/Input/SelectText";
 import { getError, normalizarOptions, normalizarPerfis } from "helpers/utils";
 import { getUsuarios, setUsuario } from "services/permissionamento.service";
-import { formataPayloadUsuario } from "../../helper";
 import { toastError, toastSuccess } from "components/Toast/dialogs";
 
 export const ModalEditarUsuario = ({
@@ -23,7 +22,7 @@ export const ModalEditarUsuario = ({
   setUsuarios,
 }) => {
   const onSubmit = (values) => {
-    setUsuario(formataPayloadUsuario(values))
+    setUsuario(values)
       .then((response) => {
         if (response.status === HTTP_STATUS.OK) {
           toastSuccess("Usuário atualizado com sucesso");
@@ -103,9 +102,6 @@ export const ModalEditarUsuario = ({
                       options={normalizarOptions(dres)}
                       naoDesabilitarPrimeiraOpcao
                     />
-                  </div>
-                  <div className="col-sm-2 col-12">
-                    <Field component={InputText} name="setor_" label="Setor" />
                   </div>
                 </div>
                 <div className="row">

--- a/src/pages/AreaLogada/Permissionamento/componentes/TabelaUsuarios/index.jsx
+++ b/src/pages/AreaLogada/Permissionamento/componentes/TabelaUsuarios/index.jsx
@@ -17,7 +17,6 @@ export const TabelaUsuarios = ({ usuarios, setShowModal, setUsuario }) => {
               <th>E-mail</th>
               <th>Secretaria</th>
               <th>DRE</th>
-              <th>Setor</th>
               <th>Tipo de Permissão</th>
               <th>Editar</th>
             </tr>
@@ -32,7 +31,6 @@ export const TabelaUsuarios = ({ usuarios, setShowModal, setUsuario }) => {
                     <td>{usuario.email}</td>
                     <td>{usuario.secretaria && usuario.secretaria.nome}</td>
                     <td>{usuario.setor && usuario.setor.dre.sigla}</td>
-                    <td>{usuario.setor && usuario.setor.codigo}</td>
                     <td>
                       {usuario.perfil ? usuario.perfil.nome : "SEM PERMISSAO"}
                     </td>

--- a/src/pages/AreaLogada/Permissionamento/helper.js
+++ b/src/pages/AreaLogada/Permissionamento/helper.js
@@ -26,12 +26,3 @@ export const formataUsuario = (usuario) => {
   usuario.perfil_ = usuario.perfil ? usuario.perfil.id : "SEM PERMISSAO";
   return usuario;
 };
-
-export const formataPayloadUsuario = (values) => {
-  if (values.setor_) {
-    if (values.setor) {
-      values.setor.codigo = values.setor_;
-    } else values.setor = { codigo: values.setor_ };
-  }
-  return values;
-};


### PR DESCRIPTION
# Proposta

Este PR visa substituir coluna setor por DRE e remover input setor da edição de permissões.

# Referência do Azure

- 31787

# Tarefas para concluir

- [x] Ordenação campo permissões.
- [x] Remover coluna setor da tabela de permissionamento.
- [x] Remover setor do modal de edição.
- [x] Melhoria nos inputs.