### PR TITLE
Fix: Validar se o valor é uma string vazia.

### DIFF
--- a/src/pages/AreaLogada/Cadastros/componentes/Filtro/index.jsx
+++ b/src/pages/AreaLogada/Cadastros/componentes/Filtro/index.jsx
@@ -155,7 +155,9 @@ export const Filtro = ({
                     />
                     <OnChange name="dre">
                       { (value, previous) => {
-                        onChangeDRE(value);
+                        if(value !== undefined && value !== ""){
+                          onChangeDRE(value);
+                        }
                       }}
                     </OnChange>
                   </div>
@@ -170,7 +172,9 @@ export const Filtro = ({
                     />
                     <OnChange name="distrito">
                       { (value, previous) => {
-                        onChangeDistrito(value);
+                        if(value !== undefined && value !== ""){
+                          onChangeDistrito(value);
+                        }
                       }}
                     </OnChange>
                   </div>


### PR DESCRIPTION
# Proposta

Este PR visa consertar problema ao fazer requisição mesmo quando o valor do filtro é vazio.

# Referência do Azure

- 31783

# Tarefas para concluir

- [x] Validar se o valor é uma string vazia.