### PR TITLE
Fix: usar data correta para texto de cancelamento

### DIFF
--- a/src/pages/Emails/components/Textos/Cancelado.js
+++ b/src/pages/Emails/components/Textos/Cancelado.js
@@ -13,7 +13,7 @@ const Cancelado = (imovel) => {
         <p>
           Em atendimento a solicitação de V.Sa. referente ao cadastro de imóvel, <b>protocolo nº 
             {imovel.imovel.protocolo}</b>, conforme dados a seguir, efetuamos o 
-            cancelamento do cadastro na presente data <b>[data_hoje]</b>.
+            cancelamento do cadastro na presente data <b>{imovel.imovel.data_cancelamento}</b>.
         </p>
         <p>
           Obrigado.


### PR DESCRIPTION
# Proposta

Este PR visa corrigir a data no e-mail de cadastro cancelado.

# Referência do Azure

- None

# Tarefas para concluir

- [x] usar data correta para texto de cancelamento
