### PR TITLE
Fix: desabilitar botão para finalizados reprovados e aprovados na vis…

### DIFF
--- a/src/pages/AreaLogada/DetalhamentoCadastro/componentes/ModalAtualizaStatus/index.jsx
+++ b/src/pages/AreaLogada/DetalhamentoCadastro/componentes/ModalAtualizaStatus/index.jsx
@@ -1388,6 +1388,7 @@ export const ModalAtualizaStatus = ({
                       onClick={() => finalizarAnalise(values, true)}
                       disabled={!finalizado || analiseFinalizadaLog.length ||
                                 finalizadoAprovadoLog.length || finalizadoReporvadoLog.length || 
+                                vistoriaReprovadaLog.length || enviadoDreLog.length || 
                                 statusCadastro === "Cancelado"}
                     />
                   </div>


### PR DESCRIPTION
# Proposta

Este PR visa desabilitar o botão de enviar e-mail nos status de "Finalizados - Aprovados na vistoria" e "Finalizados - Reprovados na vistoria". 
 
# Referência do Azure

- 39703

# Tarefas para concluir

- [x] tratar regra para desabilitar botão. 